### PR TITLE
[INFRA] Fix: Set Action Coverage To Run Only On PRs

### DIFF
--- a/.github/workflows/go-test-coverage.yaml
+++ b/.github/workflows/go-test-coverage.yaml
@@ -3,9 +3,6 @@ name: ci/coverage
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  push:
-    branches:
-      - 'main'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

Set Action Coverage To Run Only On PRs

## Checklist

- [x] Tests passed
- [ ] Changes are covered by tests
- [ ] Documentation updated
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
